### PR TITLE
Add recurrence MRI dataset support

### DIFF
--- a/Downstream/Dim_3/RecurrenceMRI/main.py
+++ b/Downstream/Dim_3/RecurrenceMRI/main.py
@@ -1,0 +1,115 @@
+import argparse
+import os
+import numpy as np
+from sklearn import metrics
+from tqdm import tqdm
+import torch
+import torch.backends.cudnn as cudnn
+from torch.utils.data import DataLoader
+
+from dataloader.Recurrence_MRI_dataset import RecurrenceMRIDataset
+from model.Unimodel import Unified_Model
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description="Recurrence classification")
+    parser.add_argument('--data_root', type=str, required=True)
+    parser.add_argument('--label_file', type=str, default='CC_end.xlsx')
+    parser.add_argument('--snapshot_dir', type=str, default='snapshots/tmp/')
+    parser.add_argument('--reload_from_pretrained', action='store_true')
+    parser.add_argument('--pretrained_path', type=str, default='checkpoint.pth')
+    parser.add_argument('--input_size', type=str, default='8,64,64')
+    parser.add_argument('--batch_size', type=int, default=2)
+    parser.add_argument('--num_epochs', type=int, default=50)
+    parser.add_argument('--learning_rate', type=float, default=1e-4)
+    parser.add_argument('--num_workers', type=int, default=4)
+    return parser
+
+
+def build_loader(args, split):
+    crop = tuple(int(x) for x in args.input_size.split(','))
+    ds = RecurrenceMRIDataset(args.data_root, split=split, label_file=args.label_file, crop_size=crop)
+    shuffle = split == 'train'
+    loader = DataLoader(ds, batch_size=args.batch_size if shuffle else 1,
+                        shuffle=shuffle, num_workers=args.num_workers,
+                        pin_memory=True)
+    return loader, crop
+
+
+def train_epoch(model, loader, optimizer):
+    model.train()
+    losses = []
+    for vol, lab in loader:
+        vol = vol.cuda(non_blocking=True)
+        lab = lab.long().cuda(non_blocking=True)
+        data = {"data": vol, "labels": lab, "modality": "3D image"}
+        optimizer.zero_grad()
+        loss = model(data)
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 12)
+        optimizer.step()
+        losses.append(loss.item())
+    return np.mean(losses)
+
+
+def evaluate(model, loader):
+    model.eval()
+    model.cal_acc = True
+    prob_list, pred_list, gt_list = [], [], []
+    with torch.no_grad():
+        for vol, lab in loader:
+            vol = vol.cuda(non_blocking=True)
+            lab = lab.long().cuda(non_blocking=True)
+            data = {"data": vol, "labels": lab, "modality": "3D image"}
+            _, prob = model(data)
+            prob = prob[:, 1].cpu().numpy()
+            pred = (prob >= 0.5).astype(np.int64)
+            prob_list.append(prob)
+            pred_list.append(pred)
+            gt_list.append(lab.cpu().numpy())
+    model.cal_acc = False
+    probs = np.concatenate(prob_list)
+    preds = np.concatenate(pred_list)
+    gts = np.concatenate(gt_list)
+    auc = metrics.roc_auc_score(gts, probs)
+    acc = metrics.accuracy_score(gts, preds)
+    tp = np.sum((preds == 1) & (gts == 1))
+    tn = np.sum((preds == 0) & (gts == 0))
+    fp = np.sum((preds == 1) & (gts == 0))
+    fn = np.sum((preds == 0) & (gts == 1))
+    sen = tp / (tp + fn + 1e-8)
+    spe = tn / (tn + fp + 1e-8)
+    return acc, auc, sen, spe
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+
+    cudnn.benchmark = True
+    train_loader, crop = build_loader(args, 'train')
+    val_loader, _ = build_loader(args, 'val')
+
+    model = Unified_Model(now_3D_input_size=crop, num_classes=2,
+                          pre_trained=args.reload_from_pretrained,
+                          pre_trained_weight=args.pretrained_path)
+    model = model.cuda()
+
+    optimizer = torch.optim.AdamW(model.parameters(), args.learning_rate, weight_decay=0.0001)
+
+    best_auc = 0.0
+    for epoch in range(args.num_epochs):
+        loss = train_epoch(model, train_loader, optimizer)
+        acc, auc, sen, spe = evaluate(model, val_loader)
+        if auc > best_auc:
+            best_auc = auc
+            os.makedirs(args.snapshot_dir, exist_ok=True)
+            torch.save({'model': model.state_dict(), 'epoch': epoch},
+                       os.path.join(args.snapshot_dir, 'checkpoint.pth'))
+        print(
+            f"Epoch {epoch}: loss {loss:.4f}, acc {acc:.4f}, auc {auc:.4f}, sen {sen:.4f}, spe {spe:.4f}"
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/Downstream/Dim_3/RecurrenceMRI/model/Base_module.py
+++ b/Downstream/Dim_3/RecurrenceMRI/model/Base_module.py
@@ -1,0 +1,578 @@
+import torch
+from torch import nn
+import torch.nn.functional as F
+from typing import Optional, Any, Union, Callable
+from torch import Tensor
+import math
+from timm.models.layers import DropPath
+try:
+    from apex.normalization import FusedLayerNorm as _FusedLayerNorm
+
+    has_fused_layernorm = True
+
+    class FusedLayerNorm(_FusedLayerNorm):
+        @torch.jit.unused
+        def forward(self, x):
+            if not x.is_cuda:
+                return super().forward(x)
+            else:
+                with torch.cuda.device(x.device):
+                    return super().forward(x)
+except ImportError:
+    has_fused_layernorm = False
+
+class DeepPrompt(torch.nn.Module):
+    # naive implementation
+    def __init__(self, cfg):
+        super().__init__()
+
+        embedding_hidden_size = cfg.MODEL.BERT.HIDDEN_SIZE
+        self.target_prompt = cfg.MODEL.PROMPT_EMBED.TARGET_DEEP_PROMPT and not cfg.MODEL.PROMPT_EMBED.SHARE_DEEP_PROMPT
+        self.embedding = torch.nn.Embedding(cfg.MODEL.PROMPT_EMBED.INPUT_DEEP_PROMPT_LENGTH, embedding_hidden_size)
+        if self.target_prompt:
+            self.target_embedding = torch.nn.Embedding(cfg.MODEL.PROMPT_EMBED.TARGET_DEEP_PROMPT_LENGTH, embedding_hidden_size)
+
+
+    def forward(self, x, batch_first=False, data_type=None, **kwargs):
+        # x: length, bs, hidden_size
+
+        if data_type == 'target' and self.target_prompt:
+            embddings = self.target_embedding.weight
+        else:
+            embddings = self.embedding.weight
+
+        if batch_first:
+            bs = x.shape[0]
+            embddings = embddings.unsqueeze(0).expand(bs, -1, -1)
+        else:
+            bs = x.shape[1]
+            embddings = embddings.unsqueeze(1).expand(-1,bs, -1)
+        return embddings
+
+def LayerNorm(normalized_shape, eps=1e-5, elementwise_affine=True, export=False):
+    if torch.jit.is_scripting():
+        export = True
+    if not export and torch.cuda.is_available() and has_fused_layernorm:
+        return FusedLayerNorm(normalized_shape, eps, elementwise_affine)
+    else:
+        return torch.nn.LayerNorm(normalized_shape, eps, elementwise_affine)
+    return torch.nn.LayerNorm(normalized_shape, eps, elementwise_affine)
+
+_ACT_LAYER_DEFAULT = dict(
+    relu=nn.ReLU,
+    elu=nn.ELU,
+    celu=nn.CELU,
+    sigmoid=nn.Sigmoid,
+    tanh=nn.Tanh,
+)
+
+def get_act_layer(name='none'):
+    if name in _ACT_LAYER_DEFAULT:
+        return _ACT_LAYER_DEFAULT[name]
+    else:
+        return None
+
+def swish(x):
+    return x * torch.sigmoid(x)
+
+def _gelu_python(x):
+    """ Original Implementation of the gelu activation function in Google Bert repo when initially created.
+        For information: OpenAI GPT's gelu is slightly different (and gives slightly different results):
+        0.5 * x * (1 + torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3))))
+        This is now written in C in torch.nn.functional
+        Also see https://arxiv.org/abs/1606.08415
+    """
+    return x * 0.5 * (1.0 + torch.erf(x / math.sqrt(2.0)))
+
+gelu = getattr(F, "gelu", _gelu_python)
+
+def gelu_new(x):
+    """ Implementation of the gelu activation function currently in Google Bert repo (identical to OpenAI GPT).
+        Also see https://arxiv.org/abs/1606.08415
+    """
+    return 0.5 * x * (1 + torch.tanh(math.sqrt(2 / math.pi) * (x + 0.044715 * torch.pow(x, 3))))
+
+def mish(x):
+    return x * torch.tanh(nn.functional.softplus(x))
+
+ACT2FN = {
+    "relu": F.relu,
+    "swish": swish,
+    "gelu": gelu,
+    "tanh": F.tanh,
+    "gelu_new": gelu_new,
+    "mish": mish
+}
+
+def get_activation(activation_string):
+    if activation_string in ACT2FN:
+        return ACT2FN[activation_string]
+    else:
+        raise KeyError(
+            "function {} not found in ACT2FN mapping {} or torch.nn.functional".format(
+                activation_string, list(ACT2FN.keys())
+            )
+        )
+
+class TransformerEncoderLayer(nn.Module):
+    r"""TransformerEncoderLayer is made up of self-attn and feedforward network.
+    This standard encoder layer is based on the paper "Attention Is All You Need".
+    Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N Gomez,
+    Lukasz Kaiser, and Illia Polosukhin. 2017. Attention is all you need. In Advances in
+    Neural Information Processing Systems, pages 6000-6010. Users may modify or implement
+    in a different way during application.
+    Args:
+        d_model: the number of expected features in the input (required).
+        nhead: the number of heads in the multiheadattention models (required).
+        dim_feedforward: the dimension of the feedforward network model (default=2048).
+        dropout: the dropout value (default=0.1).
+        activation: the activation function of the intermediate layer, can be a string
+            ("relu" or "gelu") or a unary callable. Default: relu
+        layer_norm_eps: the eps value in layer normalization components (default=1e-5).
+        batch_first: If ``True``, then the input and output tensors are provided
+            as (batch, seq, feature). Default: ``False`` (seq, batch, feature).
+        norm_first: if ``True``, layer norm is done prior to attention and feedforward
+            operations, respectivaly. Otherwise it's done after. Default: ``False`` (after).
+    Examples::
+    #     >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+    #     >>> src = torch.rand(10, 32, 512)
+    #     >>> out = encoder_layer(src)
+    # Alternatively, when ``batch_first`` is ``True``:
+    #     >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8, batch_first=True)
+    #     >>> src = torch.rand(32, 10, 512)
+    #     >>> out = encoder_layer(src)
+    Fast path:
+        forward() will use a special optimized implementation if all of the following
+        conditions are met:
+        - Either autograd is disabled (using ``torch.inference_mode`` or ``torch.no_grad``) or no tensor
+          argument ``requires_grad``
+        - training is disabled (using ``.eval()``)
+        - batch_first is ``True`` and the input is batched (i.e., ``src.dim() == 3``)
+        - norm_first is ``False`` (this restriction may be loosened in the future)
+        - activation is one of: ``"relu"``, ``"gelu"``, ``torch.functional.relu``, or ``torch.functional.gelu``
+        - at most one of ``src_mask`` and ``src_key_padding_mask`` is passed
+        - if src is a `NestedTensor <https://pytorch.org/docs/stable/nested.html>`_, neither ``src_mask``
+          nor ``src_key_padding_mask`` is passed
+        - the two ``LayerNorm`` instances have a consistent ``eps`` value (this will naturally be the case
+          unless the caller has manually modified one without modifying the other)
+        If the optimized implementation is in use, a
+        `NestedTensor <https://pytorch.org/docs/stable/nested.html>`_ can be
+        passed for ``src`` to represent padding more efficiently than using a padding
+        mask. In this case, a `NestedTensor <https://pytorch.org/docs/stable/nested.html>`_ will be
+        returned, and an additional speedup proportional to the fraction of the input that
+        is padding can be expected.
+    """
+    __constants__ = ['batch_first', 'norm_first'] # we inherit this variable from pytorch's code for jit
+
+    def __init__(self, d_model: int, nhead: int, dim_feedforward: int = 2048, dropout: float = 0.1, drop_path_ratio: float = 0.1,
+                 activation: Union[str, Callable[[Tensor], Tensor]] = F.relu, layer_scale: bool = False, ls_init_values: float = 1e-3,
+                 layer_norm_eps: float = 1e-5, batch_first: bool = False, norm_first: bool = False,
+                 device=None, dtype=None, cfg: dict = None) -> None:
+        #
+        factory_kwargs = {}
+        super(TransformerEncoderLayer, self).__init__()
+
+
+        # The interface of nn.MultiheadAttention changed since torch 1.9.0.
+        _torch_version_main = torch.__version__.split('.')[:2]
+        if (int(_torch_version_main[0]) >= 1) and (int(_torch_version_main[1])) >= 9:
+            self._torch_nn_new_interface = True
+        else:
+            self._torch_nn_new_interface = False
+
+        if self._torch_nn_new_interface:
+            factory_kwargs = {'device': device, 'dtype': dtype}
+            self.self_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout, batch_first=batch_first,
+                                                **factory_kwargs)
+        else:
+            factory_kwargs = {}
+            self.self_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout,
+                                                **factory_kwargs)
+
+        self.batch_first = batch_first
+
+        # Implementation of Feedforward model
+        self.linear1 = nn.Linear(d_model, dim_feedforward, **factory_kwargs)
+        self.dropout = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(dim_feedforward, d_model, **factory_kwargs)
+
+        self.norm_first = norm_first
+
+        self.norm1 = nn.LayerNorm(d_model, eps=layer_norm_eps, **factory_kwargs)
+        self.norm2 = nn.LayerNorm(d_model, eps=layer_norm_eps, **factory_kwargs)
+
+        self.dropout1 = nn.Dropout(dropout)
+        self.dropout2 = nn.Dropout(dropout)
+
+        self.drop_path1 = DropPath(drop_path_ratio) if drop_path_ratio > 0. else nn.Identity()
+        self.drop_path2 = DropPath(drop_path_ratio) if drop_path_ratio > 0. else nn.Identity()
+
+        self.layer_scale = layer_scale
+        if self.layer_scale:
+            self.gamma_1 = nn.Parameter(ls_init_values * torch.ones((d_model)),requires_grad=True)
+            self.gamma_2 = nn.Parameter(ls_init_values * torch.ones((d_model)),requires_grad=True)
+
+        # Legacy string support for activation function.
+        if isinstance(activation, str):
+            activation = get_activation(activation)
+
+        self.activation = activation
+        self.deep_prompt = None
+
+
+    def __setstate__(self, state):
+        if 'activation' not in state:
+            state['activation'] = F.relu
+        super(TransformerEncoderLayer, self).__setstate__(state)
+
+    def forward(self,
+                src: Tensor,
+                src_mask: Optional[Tensor] = None):
+        r"""Pass the input through the encoder layer.
+        Args:
+            src: the sequence to the encoder layer (required).
+            src_mask: the mask for the src sequence (optional).
+            src_key_padding_mask: the mask for the src keys per batch (optional).
+        Shape:
+            see the docs in Transformer class.
+        """
+
+        # see Fig. 1 of https://arxiv.org/pdf/2002.04745v1.pdf
+
+        if self.batch_first and not self._torch_nn_new_interface:
+            x = src.transpose(0,1)
+        else:
+            x = src
+
+        if self.norm_first:
+            history_states_norm = None
+            x = x + self._sa_block(self.norm1(x), src_mask, None, history_states=history_states_norm)
+            x = x + self._ff_block(self.norm2(x))
+        else:
+            x = self.norm1(x + self._sa_block(x, src_mask, None, history_states=None))
+            x = self.norm2(x + self._ff_block(x))
+
+        if self.batch_first and not self._torch_nn_new_interface:
+            x = x.transpose(0, 1)
+
+        return x
+
+    # self-attention block
+    def _sa_block(self, x: Tensor, attn_mask: Optional[Tensor], key_padding_mask: Optional[Tensor], history_states: Optional[Tensor],
+                  **kwargs) -> Tensor:
+
+        if history_states is not None:
+            kv = torch.cat(
+                [history_states, x],
+                dim=1 if (self.batch_first and self._torch_nn_new_interface) else 0
+            )
+        else:
+            kv = x
+
+        if self.deep_prompt:
+
+            deep_prompt_embedding = self.deep_prompt_embedding(x, batch_first=(self.batch_first and self._torch_nn_new_interface), **kwargs)
+            if self.norm_first:
+                deep_prompt_embedding = self.norm1(deep_prompt_embedding)
+            kv = torch.cat([deep_prompt_embedding, kv], dim=1 if (self.batch_first and self._torch_nn_new_interface) else 0)
+            if attn_mask is not None:
+                L, S = attn_mask.shape
+                pe_length = deep_prompt_embedding.shape[1 if
+                                                        (self.batch_first and self._torch_nn_new_interface) else 0]  # length, bs, hidden_size
+                attn_mask = torch.cat([torch.zeros((L, pe_length), dtype=attn_mask.dtype, device=attn_mask.device), attn_mask], dim=1)
+            if key_padding_mask is not None:
+                if self.batch_first and self._torch_nn_new_interface:
+                    bs, pe_length = deep_prompt_embedding.shape[:2]
+                else:
+                    pe_length, bs = deep_prompt_embedding.shape[:2]
+                key_padding_mask = torch.cat(
+                    [torch.zeros((bs, pe_length), dtype=key_padding_mask.dtype, device=key_padding_mask.device), key_padding_mask], dim=1)
+
+        x = self.self_attn(x, kv, kv,
+                           attn_mask=attn_mask,
+                           key_padding_mask=key_padding_mask,
+                           need_weights=False)[0]
+        x = self.drop_path1(self.dropout1(x))
+        if self.layer_scale:
+            x = self.gamma_1 * x
+        return x
+
+
+    # feed forward block
+    def _ff_block(self, x: Tensor, **kwargs) -> Tensor:
+        x = self.linear2(self.dropout(self.activation(self.linear1(x))))
+        x = self.drop_path2(self.dropout2(x))
+        if self.layer_scale:
+            x = self.gamma_2 * x
+        return x
+
+
+import torch
+from torch import nn
+import copy
+import math
+import torch
+from torch import nn
+
+def build_position_encoding(dim, max_len):
+    return NNEmbeddingEncoding(dim, max_len)
+
+
+class SinusoidEncoding(nn.Module):
+    def __init__(self, dim, max_len):
+        super(SinusoidEncoding, self).__init__()
+        pe = torch.zeros(max_len, dim)
+        position = torch.arange(0, max_len).unsqueeze(1).float()
+        div_term = torch.exp(torch.arange(0, dim, 2).float() *
+                             -(math.log(max_len * 2.0) / dim))
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)
+        self.register_buffer('pe', pe)
+
+    def forward(self, x):
+        if isinstance(x, int):
+            return self.pe[:, x]
+        else:
+            x_size = x.size(1)
+            return self.pe[:, :x_size]
+
+
+class NNEmbeddingEncoding(nn.Module):
+    def __init__(self, dim, max_len):
+        super(NNEmbeddingEncoding, self).__init__()
+        self.position_embeddings = nn.Embedding(max_len, dim)
+
+    def forward(self, x, start_time=0):
+        if isinstance(x, int):
+            position_embeddings = self.position_embeddings(torch.tensor([x], dtype=torch.long).cuda())
+        elif isinstance(x, torch.Tensor) and x.dim()==1:
+            position_embeddings = self.position_embeddings(x)
+        else:
+            x_size = x.size(1)
+            position_ids = torch.arange(x_size, dtype=torch.long, device=x.device) + start_time
+            position_embeddings = self.position_embeddings(position_ids)
+        return position_embeddings
+
+class TokenBaseEmbedding(nn.Module):
+
+    def __init__(
+        self,
+        dim=768,
+        vocab_size=49411, # include <BOS>/<EOS>
+        **kwargs
+    ):
+        super(TokenBaseEmbedding, self).__init__()
+        kwargs = {
+            "dim": 768,
+            "vocab_size": 49411
+        }
+
+        activation_name = ('none').lower()
+        if activation_name != "none":
+            activation = get_act_layer(activation_name)
+            assert activation is not None
+
+            act_kwargs = {}
+            embeddings_act = activation(**act_kwargs)
+            kwargs['embeddings_act'] = embeddings_act
+
+        embeddings_norm = nn.LayerNorm(768)
+        kwargs['embeddings_norm'] = embeddings_norm
+
+        embeddings_pos = build_position_encoding(768, 512)
+        kwargs['embeddings_pos'] = embeddings_pos
+
+        embeddings_token_type = nn.Embedding(2, 768)
+        kwargs['embeddings_token_type'] = embeddings_token_type
+
+        self.embeddings = nn.Embedding(vocab_size, dim)
+        self.embeddings_act = kwargs.pop("embeddings_act", None)
+        self.embeddings_norm = kwargs.pop("embeddings_norm", None)
+        self.embeddings_dropout = kwargs.pop("embeddings_dropout", None)
+        self.embeddings_pos = kwargs.pop("embeddings_pos", None)
+        self.embeddings_token_type = kwargs.pop('embeddings_token_type', None)
+        self.embeddings_token_seg = kwargs.pop('embeddings_token_seg', None)
+        self.bw_own_embed = kwargs.pop('bw_own_embed', False)
+        self.pos_before = kwargs.pop('pos_before', True)
+
+
+
+        if self.bw_own_embed:
+            # only for debugging
+            self.bw_embeddings = copy.deepcopy(self.embeddings)
+            self.bw_embeddings_norm = copy.deepcopy(self.embeddings_norm)
+            self.bw_embeddings_pos = copy.deepcopy(self.embeddings_pos)
+            self.bw_embeddings_token_type = copy.deepcopy(self.embeddings_token_type)
+        self.s_token_bias = None
+
+
+
+    def set_s_token_bias(self, s_token_bias):
+        self.s_token_bias = s_token_bias
+
+    def forward(self, input_ids):
+
+        embeddings = self.embeddings(input_ids)
+
+
+        if self.s_token_bias is not None:
+            # learnable
+            embeddings[input_ids == 49410] = embeddings[input_ids == 49410] + self.s_token_bias
+
+        if self.embeddings_pos is not None:
+            pos_inputs = input_ids
+            position_embeddings = self.embeddings_pos(pos_inputs)
+            embeddings = embeddings + position_embeddings.to(embeddings.dtype)
+
+        if self.embeddings_token_type is not None:
+
+            embeddings_token_type = self.embeddings_token_type.weight[0].unsqueeze(0).unsqueeze(1)
+            embeddings = embeddings + embeddings_token_type.to(embeddings.dtype)
+
+        if self.embeddings_act is not None:
+            embeddings = self.embeddings_act(embeddings)
+
+        if self.embeddings_norm is not None:
+            embeddings = self.embeddings_norm(embeddings)
+
+        if self.embeddings_pos is not None and not self.pos_before:
+            pos_inputs = input_ids
+            position_embeddings = self.embeddings_pos(pos_inputs)
+            embeddings = embeddings + position_embeddings.to(embeddings.dtype)
+        if self.embeddings_dropout is not None:
+            embeddings = self.embeddings_dropout(embeddings)
+        return embeddings
+
+import torch
+from torch import nn
+from einops import rearrange, repeat
+
+class VideoBaseEmbedding(nn.Module):
+
+    def __init__(
+        self,
+        in_dim=768,
+        out_dim=768,
+        patch_size=16,
+        input_size_3D=None,
+        input_size_2D=None,
+        max_spatial_size = 196,
+
+    ):
+        super(VideoBaseEmbedding, self).__init__()
+        kwargs = {
+            "in_dim": 768,
+            "out_dim": 768,
+            "patch_size": 16,
+            "time_span": 1,
+            "max_time_len": 8,
+        }
+        max_spatial_size = (input_size_3D[0] // patch_size) *  (input_size_3D[1] // patch_size) * (input_size_3D[2] // patch_size)
+        max_spatial_size_2D =(input_size_2D[0] // patch_size) *  (input_size_2D[1] // patch_size)
+        kwargs['max_spatial_size'] = max_spatial_size
+        # activation_name = ('none').lower()
+
+
+        embeddings_norm = nn.LayerNorm(768)
+        self.embeddings_norm = embeddings_norm
+
+
+        kwargs['embeddings_pos'] = "divide_st_pos"
+
+        self.embeddings = nn.Linear(in_dim, out_dim)
+        self.embeddings_act = kwargs.pop("embeddings_act", None)
+
+        self.embeddings_dropout = kwargs.pop("embeddings_dropout", None)
+
+        self.random_temporal_pos = kwargs.pop("random_temporal_pos", True)
+        self.patch_size = patch_size
+        self.time_span =  kwargs.pop("time_span", None)
+        self.pos_before = kwargs.pop('pos_before', True)
+
+
+
+        self.embeddings_st_pos = None
+        self.max_spatial_size = max_spatial_size
+        self.embeddings_st_pos_2D = Divide_ST_POS(
+            max_spatial_size_2D, 8, out_dim,
+            self.random_temporal_pos)
+        self.embeddings_st_pos_3D = Divide_ST_POS(
+            max_spatial_size, 8, out_dim,
+            self.random_temporal_pos)
+        # self.embeddings_pos = None
+        del self.embeddings
+
+        self.embeddings = nn.Conv2d(3, out_dim, kernel_size=self.patch_size, stride=self.patch_size)
+        self.embeddings_3D = nn.Conv3d(1, out_dim, kernel_size=self.patch_size, stride=self.patch_size)
+
+        # print("video embedding", self.pos_before)
+
+    def forward(self, data):
+
+        if data.dim() == 4:
+            bs = data.size(0)
+            # print(data.size())
+            x = self.embeddings(data) # b*t, dim, 14, 14
+            x = x.flatten(2) # .flatten(2)
+            # print(x.size())
+            embeddings = rearrange(x, '(b t s) c hw -> b t hw (s c)', b=bs,  s = self.time_span)
+            # print(embeddings.size())
+            embeddings_pos = self.embeddings_st_pos_2D(embeddings).unsqueeze(
+                0).flatten(1, 2)
+            embeddings = embeddings.flatten(1, 2)
+            if self.pos_before:
+                embeddings = embeddings + embeddings_pos.to(embeddings.dtype)
+
+        elif data.dim() == 5:
+            bs = data.size(0)
+            # print(data.size())
+            x = self.embeddings_3D(data)  # b*t, dim, 14, 14
+            x = x.flatten(2)  # .flatten(2)
+            # print(x.size())
+            embeddings = rearrange(x, '(b t s) c dhw -> b t dhw (s c)', b=bs, s=self.time_span)
+            # print(embeddings.size())
+            embeddings_pos = self.embeddings_st_pos_3D(embeddings).unsqueeze(
+                0).flatten(1, 2)
+            embeddings = embeddings.flatten(1, 2)
+            if self.pos_before:
+                embeddings = embeddings + embeddings_pos.to(embeddings.dtype)
+
+        if self.embeddings_act is not None:
+            embeddings = self.embeddings_act(embeddings)
+
+        if self.embeddings_norm is not None:
+            embeddings = self.embeddings_norm(embeddings)
+
+        if not self.pos_before:
+            embeddings = embeddings + embeddings_pos
+
+        if self.embeddings_dropout is not None:
+            embeddings = self.embeddings_dropout(embeddings)
+
+        return embeddings
+
+
+
+class Divide_ST_POS(nn.Module):
+    def __init__(self, num_patches, max_time_len, out_dim,
+                 random_temporal_pos):
+        super(Divide_ST_POS, self).__init__()
+        self.spatial_pos_embed = nn.Embedding(num_patches, out_dim)
+        self.temporal_pos_embed = nn.Embedding(max_time_len, out_dim)
+        self.spatial_pos_embed_index = 0 # sometimes image has cls_token
+        self.max_frames = max_time_len
+        self.random_temporal_pos = random_temporal_pos
+
+    def forward(self, x):
+        dtype = x.dtype
+        temp_len, spatial_size = x.size(1), x.size(2)
+
+        if self.training and self.random_temporal_pos:
+            temporal_pos_ids = torch.arange(temp_len, dtype=torch.long, device=x.device) + \
+                torch.randint(0, self.max_frames - temp_len + 1, size=(1,), dtype=torch.long, device=x.device)
+        else:
+            temporal_pos_ids = torch.arange(temp_len, dtype=torch.long, device=x.device)
+        pos_embed = self.temporal_pos_embed(temporal_pos_ids).unsqueeze(1).to(dtype=dtype) + \
+            self.spatial_pos_embed(torch.arange(start= self.spatial_pos_embed_index, end=spatial_size +  self.spatial_pos_embed_index , dtype=torch.long, device=x.device)).unsqueeze(0).to(dtype=dtype)
+        return pos_embed

--- a/Downstream/Dim_3/RecurrenceMRI/model/Unimodel.py
+++ b/Downstream/Dim_3/RecurrenceMRI/model/Unimodel.py
@@ -1,0 +1,228 @@
+import torch
+from torch import nn
+from model.Base_module import TransformerEncoderLayer, TokenBaseEmbedding, VideoBaseEmbedding
+from functools import partial
+from timm.models.vision_transformer import Block
+import numpy as np
+from transformers.models.bert.modeling_bert import BertPredictionHeadTransform
+import torch.nn.functional as F
+from sklearn.metrics import accuracy_score, auc
+import cv2
+from transformers import (
+    DataCollatorForLanguageModeling,
+    DataCollatorForWholeWordMask,
+    BertTokenizerFast,
+    RobertaTokenizerFast
+)
+
+class BertPredictionHeadTransform(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.dense = nn.Linear(768, 768)
+        self.transform_act_fn = nn.GELU()
+
+        self.LayerNorm = nn.LayerNorm(768, eps=1e-12)
+
+    def forward(self, hidden_states):
+        hidden_states = self.dense(hidden_states)
+        hidden_states = self.transform_act_fn(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states)
+        return hidden_states
+
+class MLMHead(nn.Module):
+    def __init__(self, weight=None):
+        super().__init__()
+        self.transform = BertPredictionHeadTransform()
+        self.decoder = nn.Linear(768, 49411, bias=False)
+        self.bias = nn.Parameter(torch.zeros(49411))
+        if weight is not None:
+            self.decoder.weight = weight
+
+    def forward(self, x):
+        x = self.transform(x)
+        x = self.decoder(x) + self.bias
+        return x
+
+
+class Encoder(nn.Module):
+
+    def __init__(self):
+        super(Encoder, self).__init__()
+        layers = []
+        dpr = [0.1 for _ in range(12)]
+        for layer_idx in range(12):
+
+            layers.append(
+                TransformerEncoderLayer(
+                    d_model=768,
+                    nhead=12,
+                    dim_feedforward=3072,
+                    dropout=0.,
+                    drop_path_ratio=dpr[layer_idx],
+                    activation="gelu",
+                    layer_scale=True,
+                    ls_init_values=1e-3,
+                    batch_first=True,
+                    norm_first=True,
+                ))
+        self.layers = nn.ModuleList(
+            layers
+        )
+
+    def forward(self, data, mask=None):
+
+        for l, layer_module in enumerate(self.layers):
+            data = layer_module(src=data, src_mask=mask)
+        return data
+
+def get_2d_sincos_pos_embed(embed_dim, grid_size, cls_token=False):
+    """
+    grid_size: int of the grid height and width
+    return:
+    pos_embed: [grid_size*grid_size, embed_dim] or [1+grid_size*grid_size, embed_dim] (w/ or w/o cls_token)
+    """
+    grid_h = np.arange(grid_size, dtype=np.float32)
+    grid_w = np.arange(grid_size, dtype=np.float32)
+    grid = np.meshgrid(grid_w, grid_h)  # here w goes first
+    grid = np.stack(grid, axis=0)
+
+    grid = grid.reshape([2, 1, grid_size, grid_size])
+    pos_embed = get_2d_sincos_pos_embed_from_grid(embed_dim, grid)
+    if cls_token:
+        pos_embed = np.concatenate([np.zeros([1, embed_dim]), pos_embed], axis=0)
+    return pos_embed
+
+
+def get_2d_sincos_pos_embed_from_grid(embed_dim, grid):
+    assert embed_dim % 2 == 0
+
+    # use half of dimensions to encode grid_h
+    emb_h = get_1d_sincos_pos_embed_from_grid(embed_dim // 2, grid[0])  # (H*W, D/2)
+    emb_w = get_1d_sincos_pos_embed_from_grid(embed_dim // 2, grid[1])  # (H*W, D/2)
+
+    emb = np.concatenate([emb_h, emb_w], axis=1) # (H*W, D)
+    return emb
+
+
+def get_1d_sincos_pos_embed_from_grid(embed_dim, pos):
+    """
+    embed_dim: output dimension for each position
+    pos: a list of positions to be encoded: size (M,)
+    out: (M, D)
+    """
+    assert embed_dim % 2 == 0
+    omega = np.arange(embed_dim // 2, dtype=np.float)
+    omega /= embed_dim / 2.
+    omega = 1. / 10000**omega  # (D/2,)
+
+    pos = pos.reshape(-1)  # (M,)
+    out = np.einsum('m,d->md', pos, omega)  # (M, D/2), outer product
+
+    emb_sin = np.sin(out) # (M, D/2)
+    emb_cos = np.cos(out) # (M, D/2)
+
+    emb = np.concatenate([emb_sin, emb_cos], axis=1)  # (M, D)
+    return emb
+
+
+class Unified_Model(nn.Module):
+    def __init__(self, now_3D_input_size, input_size_3D=(256, 256, 256), input_size_2D=(512, 512), in_chans=1, patch_size=16, num_classes=2,
+                 pre_trained=False, pre_trained_weight=None, global_pooling=True):
+        super(Unified_Model, self).__init__()
+        self.num_head = 12
+        self.fused_encoder = Encoder()
+        self.video_embed = VideoBaseEmbedding(input_size_3D=input_size_3D, input_size_2D=input_size_2D)
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, 768))
+        self.patch_size = patch_size
+        self.now_input_size_3D = now_3D_input_size
+        self.input_size_3D = input_size_3D
+        self.patch_size = patch_size
+        self.global_pooling = global_pooling
+        self.fc_norm = nn.LayerNorm(768, eps=1e-6)
+        self.head = nn.Sequential(
+            nn.Linear(768, 768),
+            nn.LayerNorm(768),
+            nn.GELU(),
+            nn.Linear(768, num_classes),
+        )
+
+        self.cal_acc = False
+        self.initialize_weights()
+
+        if pre_trained:
+            print("load parameters from ", pre_trained_weight)
+            model_dict = self.state_dict()
+            pre_dict = torch.load(pre_trained_weight, map_location='cpu')["model"]
+            pre_dict_update = {k: v for k, v in pre_dict.items() if k in model_dict}
+
+            pre_dict_no_update = [k for k in pre_dict.keys() if k not in model_dict]
+            print("no update: ", pre_dict_no_update)
+            print("[pre_%d/mod_%d]: %d shared layers" % (len(pre_dict), len(model_dict), len(pre_dict_update)))
+            model_dict.update(pre_dict_update)
+            self.load_state_dict(model_dict)
+
+    def init_weights_embedding(self, module):
+        if isinstance(module, (nn.Linear, nn.Embedding)):
+            module.weight.data.normal_(mean=0.0, std=0.02)
+        elif isinstance(module, nn.LayerNorm):
+            module.bias.data.zero_()
+            module.weight.data.fill_(1.0)
+
+        if isinstance(module, nn.Linear) and module.bias is not None:
+            module.bias.data.zero_()
+
+    def initialize_weights(self):
+        torch.nn.init.normal_(self.cls_token, std=.02)
+        self.apply(self._init_weights)
+
+    def _init_weights(self, m):
+        if isinstance(m, nn.Linear):
+            # we use xavier_uniform following official JAX ViT:
+            torch.nn.init.xavier_uniform_(m.weight)
+            if isinstance(m, nn.Linear) and m.bias is not None:
+                nn.init.constant_(m.bias, 0)
+        elif isinstance(m, nn.LayerNorm):
+            nn.init.constant_(m.bias, 0)
+            nn.init.constant_(m.weight, 1.0)
+
+    def _tokenize(self, data):
+        # toknizer
+        if data['modality'] in ['2D image'] or data['modality'] in ['3D image']:
+            data['data'] = self.video_embed(data["data"])
+        elif data['modality'] == 'text':
+            data['data'] = self.token_embed(data["data"])
+        else:
+            raise NotImplementedError
+
+
+    def forward(self, data):
+        self._tokenize(data)
+        if data["modality"] != "text":
+            # append cls token
+            x = data["data"]
+            cls_token = self.cls_token
+            cls_tokens = cls_token.expand(x.shape[0], -1, -1)
+            x = torch.cat((cls_tokens, x), dim=1)
+
+            x = self.fused_encoder(x, None)
+
+            if self.global_pooling:
+                x = x[:,1:, :].mean(dim=1)
+                x = self.fc_norm(x)
+
+                cls_logits = self.head(x)
+                cls_loss = F.cross_entropy(cls_logits, data["labels"])
+
+                if self.cal_acc:
+                    cls_logits_argmax = torch.argmax(cls_logits, dim=1)
+                    sklearn_accuracy = accuracy_score(data["labels"].cpu().numpy(),
+                                                      cls_logits_argmax.cpu().numpy())
+                    return sklearn_accuracy, F.softmax(cls_logits, dim=1)
+
+                return cls_loss
+
+            else:
+                pass
+        else:
+           pass
+

--- a/README.md
+++ b/README.md
@@ -101,3 +101,29 @@ The whole framework is based on [MAE](https://github.com/facebookresearch/mae), 
 
 ## Contact
 Yiwen Ye (ywye@mail.nwpu.edu.cn)
+
+## Custom Recurrence MRI Dataset
+To run binary recurrence classification with paired T1/T2 MR volumes and ROIs, place the data as follows:
+
+```
+root_folder/
+    train/ID_xxx/{t1_image.nii.gz,t1_roi.nii.gz,t2_image.nii.gz,t2_roi.nii.gz}
+    val/ID_xxx/{...}
+    test/ID_xxx/{...}
+    CC_end.xlsx
+```
+`CC_end.xlsx` must contain two columns: `SampleID` matching the folder names and `Recurrence` (0/1 label).
+
+Use the provided script `Downstream/Dim_3/RecurrenceMRI/main.py` with `dataloader/Recurrence_MRI_dataset.py`:
+
+```bash
+python Downstream/Dim_3/RecurrenceMRI/main.py \
+    --data_root /path/to/root_folder \
+    --snapshot_dir snapshots/recurrence/ \
+    --input_size 8,64,64 \
+    --batch_size 2 \
+    --num_epochs 50 \
+    --reload_from_pretrained --pretrained_path /path/to/pretrained_weight.pth
+```
+
+The script will save the best checkpoint in `--snapshot_dir` based on validation AUC. Each epoch prints accuracy, AUC, sensitivity and specificity on the validation set.

--- a/dataloader/Recurrence_MRI_dataset.py
+++ b/dataloader/Recurrence_MRI_dataset.py
@@ -1,0 +1,70 @@
+import os
+import numpy as np
+import pandas as pd
+import nibabel as nib
+from torch.utils.data import Dataset
+from skimage.transform import resize
+
+
+class RecurrenceMRIDataset(Dataset):
+    """Dataset for binary recurrence classification using paired T1/T2 MR volumes.
+
+    The ROI union is cropped and resized to ``crop_size`` (depth, height, width).
+    Channels correspond to normalized T1 and T2 volumes.
+    """
+
+    def __init__(self, root_dir, split="train", label_file="CC_end.xlsx", crop_size=(8, 64, 64)):
+        self.root = os.path.join(root_dir, split)
+        self.crop_size = crop_size
+        label_path = os.path.join(root_dir, label_file)
+        df = pd.read_excel(label_path)
+        self.labels = {str(k): int(v) for k, v in zip(df["SampleID"], df["Recurrence"])}
+        self.samples = []
+        for sid in sorted(os.listdir(self.root)):
+            if sid in self.labels:
+                base = os.path.join(self.root, sid)
+                self.samples.append({
+                    "t1": os.path.join(base, "t1_image.nii.gz"),
+                    "t1_roi": os.path.join(base, "t1_roi.nii.gz"),
+                    "t2": os.path.join(base, "t2_image.nii.gz"),
+                    "t2_roi": os.path.join(base, "t2_roi.nii.gz"),
+                    "label": self.labels[sid],
+                })
+        print(f"{split}: loaded {len(self.samples)} samples from {self.root}")
+
+    def __len__(self):
+        return len(self.samples)
+
+    def _load_volume(self, path):
+        return nib.load(path).get_fdata().astype(np.float32)
+
+    def _normalize(self, vol):
+        mean = vol.mean()
+        std = vol.std() + 1e-8
+        vol = (vol - mean) / std
+        return np.clip(vol, -5.0, 5.0)
+
+    def _crop_to_bbox(self, vol, bbox):
+        return vol[bbox[0]:bbox[1], bbox[2]:bbox[3], bbox[4]:bbox[5]]
+
+    def __getitem__(self, idx):
+        item = self.samples[idx]
+        t1 = self._load_volume(item["t1"])
+        t2 = self._load_volume(item["t2"])
+        roi1 = self._load_volume(item["t1_roi"]) > 0
+        roi2 = self._load_volume(item["t2_roi"]) > 0
+        mask = roi1 | roi2
+        pos = np.where(mask)
+        zmin, zmax = pos[0].min(), pos[0].max() + 1
+        ymin, ymax = pos[1].min(), pos[1].max() + 1
+        xmin, xmax = pos[2].min(), pos[2].max() + 1
+        t1 = self._crop_to_bbox(t1, (zmin, zmax, ymin, ymax, xmin, xmax))
+        t2 = self._crop_to_bbox(t2, (zmin, zmax, ymin, ymax, xmin, xmax))
+        t1 = self._normalize(t1)
+        t2 = self._normalize(t2)
+        volume = np.stack([
+            t1 * mask[zmin:zmax, ymin:ymax, xmin:xmax],
+            t2 * mask[zmin:zmax, ymin:ymax, xmin:xmax]
+        ], axis=0)
+        volume = resize(volume, (2,) + self.crop_size, order=1, preserve_range=True, anti_aliasing=True)
+        return volume.astype(np.float32), np.int64(item["label"])


### PR DESCRIPTION
## Summary
- implement `RecurrenceMRIDataset` for paired T1/T2 MR volumes with ROIs
- add training script for binary recurrence prediction
- document dataset structure and usage in README
- normalize volumes and compute accuracy, AUC, sensitivity and specificity

## Testing
- `python -m py_compile Downstream/Dim_3/RecurrenceMRI/main.py dataloader/Recurrence_MRI_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_68887061115483298eb529c76f86c7c4